### PR TITLE
get_the_ID() is unnecessary inside get_post_type()

### DIFF
--- a/templates/search-results.php
+++ b/templates/search-results.php
@@ -21,7 +21,7 @@
 
 <?php if ( have_posts() ) : ?>
 	<?php while ( have_posts() ) : the_post(); ?>
-		<?php $post_type = get_post_type_object( get_post_type( get_the_ID() ) ); ?>
+		<?php $post_type = get_post_type_object( get_post_type() ) ); ?>
 		<div class="searchwp-live-search-result">
 			<p><a href="<?php echo get_permalink(); ?>">
 				<?php the_title(); ?> (<?php echo $post_type->labels->singular_name; ?>) &raquo;


### PR DESCRIPTION
When inside a loop, get_post_type() defaults to the current post if none is passed.
