### PR TITLE
Fix for not showing CPTs in results

### DIFF
--- a/includes/class-client.php
+++ b/includes/class-client.php
@@ -41,6 +41,7 @@ class SearchWP_Live_Search_Client extends SearchWP_Live_Search {
 				// SearchWP powered search
 				$posts = $this->searchwp( $query );
 				$args = array(
+					'post_type' => 'any',
 					'post__in'  => $posts,
 					'orderby'   => 'post__in',
 				);


### PR DESCRIPTION
I discovered that the query_posts() function must have a post_type defined, otherwise post__in won’t retrieve any results (that are a CPT I think).

Thanks for this plugin!
