### PR TITLE
Prevents multiple requests from overlapping

### DIFF
--- a/assets/javascript/source/searchwp-live-search.js
+++ b/assets/javascript/source/searchwp-live-search.js
@@ -102,6 +102,10 @@
 
 				// bind to keyup
 				$input.keyup(function(){
+					// is there already a request active?
+					if( self.current_request ){
+						self.current_request.abort();
+					}					
 					if(!$.trim(self.input_el.val()).length) {
 						self.destroy_results();
 					}
@@ -216,9 +220,7 @@
 
 			this.last_string = $input.val();
 			this.has_results = true;
-			if( this.current_request ){
-				this.current_request.abort();
-			}
+			// put the request into the current_request var
 			this.current_request = $.ajax({
 				url: searchwp_live_search_params.ajaxurl,
 				type: "POST",


### PR DESCRIPTION
If the user starts typing again while a request is in progress, a new request will be made resulting in an overlap.
Overlapping requests give the appearance of the results flickering as they complete. This patch simply aborts the current request if the user starts typing again.
