### PR TITLE
Adding encodeURIComponent to the search term.

### DIFF
--- a/assets/javascript/build/searchwp-live-search.js
+++ b/assets/javascript/build/searchwp-live-search.js
@@ -751,7 +751,7 @@
 			this.aria_expanded( false );
 
 			// append our action, engine, and (redundant) query (so as to save the trouble of finding it again server side)
-			values += '&action=searchwp_live_search&swpengine=' + $input.data('swpengine') + '&swpquery=' + $input.val();
+			values += '&action=searchwp_live_search&swpengine=' + $input.data('swpengine') + '&swpquery=' + encodeURIComponent($input.val());
 
 			if(action.indexOf('?') !== -1){
 				action = action.split('?');


### PR DESCRIPTION
We noticed that a search term containing an ampersand didn't work correctly. The `values` variable looks like this when searching for "q&a":

`s=q%26a&action=searchwp_live_search&swpengine=default&swpquery=q&a`

As you can see, the `s` parameter has proper encoding, but `swpquery` doesn't have, and thus the search term is seen as just "q".

I wrapped the `$input.val()` in an `encodeURIComponent()` so that it gets encoded. That seems to fix the issue.