### PR TITLE
Add search string like an argument for action "searchwp_live_search_alter_results"

### DIFF
--- a/includes/class-client.php
+++ b/includes/class-client.php
@@ -131,7 +131,7 @@ class SearchWP_Live_Search_Client extends SearchWP_Live_Search {
 			$wp_query->found_posts = count( $this->results );
 		}
 
-		do_action( 'searchwp_live_search_alter_results' );
+		do_action( 'searchwp_live_search_alter_results', $args['s']);
 
 		// optionally pass along the SearchWP engine if applicable
 		$engine = isset( $_REQUEST['swpengine'] ) ? sanitize_text_field( $_REQUEST['swpengine'] ) : '';


### PR DESCRIPTION
Hi! Thank you for the awesome plugin.

Somebody may need to make changes to search results or add a "Search more %s".
And all these functions would be realized with add action 'searchwp_live_search_alter_results' with the search string as an argument. 
