### PR TITLE
Allow modifying native search via search form

### DIFF
--- a/includes/class-client.php
+++ b/includes/class-client.php
@@ -103,17 +103,22 @@ class SearchWP_Live_Search_Client extends SearchWP_Live_Search {
 				);
 			} else {
 				// native WordPress search
-				$args = array(
-					's'           => $query,
-					'post_status' => 'publish',
-					'post_type'   => get_post_types( array(
+				$args = $_POST;
+				$args['s'] = $query;
+				if ( ! isset( $_REQUEST['post_status'] ) ) {
+					$args['post_status'] = 'publish';
+				}
+				if ( ! isset( $_REQUEST['post_type'] ) ) {
+					$args['post_type'] = get_post_types( array(
 						'public'              => true,
 						'exclude_from_search' => false,
-					) ),
-				);
+					) );
+				}
 			}
 
-			$args['posts_per_page'] = $this->get_posts_per_page();
+			$args['posts_per_page'] = ( isset( $_REQUEST['posts_per_page'] )
+				? intval( $_REQUEST['posts_per_page'] )
+				: $this->get_posts_per_page() ); 
 
 			$args = apply_filters( 'searchwp_live_search_query_args', $args );
 


### PR DESCRIPTION
This PR lets you modify the search query for **native WP search** by adding hidden form fields to the search form like

`<input type="hidden" name="posts_per_page" value="20">`

or

`<input type="hidden" name="post_types" value="post,product">`

or

`<input type="hidden" name="cat" value="1,17,126">`

or

`<input type="hidden" name="category_name" value="books">`

This allows you to do some basic filtering and tuning on a *form by form* basis, as opposed to using the `searchwp_live_search_query_args` filter or the `searchwp_live_search_posts_per_page` filter which operate on all forms.

This PR yields a simple-ish solution for issues:
#51 #86 #75 #31 #115.