### PR TITLE
Enable the live search also for WooCommerce search

### DIFF
--- a/includes/class-form.php
+++ b/includes/class-form.php
@@ -79,6 +79,11 @@ class SearchWP_Live_Search_Form extends SearchWP_Live_Search {
 		add_filter( 'get_search_form', array( $this, 'get_search_form' ), 999, 1 );
 		add_action( 'wp_footer', array( $this, 'base_styles' ) );
 
+		// WooCommerce widget search integration.
+		if ( class_exists( 'woocommerce' ) ) {
+			add_filter( 'get_product_search_form', array( $this, 'get_search_form' ), 999, 1 );
+		}
+		
 		// Gutenberg integration.
 		add_filter( 'wp_footer', array( $this, 'gutenberg_integration' ) );
 


### PR DESCRIPTION
Since WooCommerce has introduced [wc_widget_product_searchwidget](https://woocommerce.wp-a2z.org/oik_api/wc_widget_product_searchwidget/) it would be really nice (and also easy) to add live search for the WooCommerce search widget as well... since it only searches among the products and the search returns a WooCommerce page with the queried products it would be an interesting feature to add.